### PR TITLE
Removed extra prints and updated region_reader

### DIFF
--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -134,9 +134,20 @@ bool Genotyper::ProcessLocus(BamCramMultiReader* bamreader, Locus* locus) {
 	locus->hib1 = hib1;
 	locus->hib2 = hib2;
 	
-	cerr<<">>Genotyper Results:\t"<<allele1<<", "<<allele2<<"\tlikelihood = "<<min_negLike<<"\n";
-	cerr<<"@@Small Allele Bound:\t["<<lob1<<", "<<hib1<<"]\n";
-	cerr<<"@@Large Allele Bound:\t["<<lob2<<", "<<hib2<<"]\n";
+
+	stringstream msg;
+	msg<<"\tGenotyper Results:  "<<allele1<<", "<<allele2<<"\tlikelihood = "<<min_negLike;
+	PrintMessageDieOnError(msg.str(), M_PROGRESS);
+	if (options->verbose) {
+	  msg.clear();
+	  msg.str(std::string());
+	  msg<<"\tSmall Allele Bound: ["<<lob1<<", "<<hib1<<"]";
+	  PrintMessageDieOnError(msg.str(), M_PROGRESS);
+	  msg.clear();
+	  msg.str(std::string());
+	  msg<<"\tLarge Allele Bound: ["<<lob2<<", "<<hib2<<"]";
+	  PrintMessageDieOnError(msg.str(), M_PROGRESS);
+	}
       }
       catch (std::exception &exc){
 	if (options->verbose) {

--- a/src/likelihood_maximizer.cpp
+++ b/src/likelihood_maximizer.cpp
@@ -428,7 +428,7 @@ bool LikelihoodMaximizer::OptimizeLikelihood(const int32_t& read_len,
   int32_t upper_bound = 600; // TODO Change 200 for number depending the parameters
   int32_t lower_bound_1d, lower_bound_2d;
   
-  
+  /*
   if (!resampled){
     double res;
     int fix = 40;
@@ -437,8 +437,7 @@ bool LikelihoodMaximizer::OptimizeLikelihood(const int32_t& read_len,
       cerr << ii << ", "<< fix <<" ->\t" << res << endl;
     } 
   }
-  //return false;
-  
+  */
 
   lower_bound_1d = 1;
   lower_bound_2d = 1;


### PR DESCRIPTION
- Removed additional lines printed in output

- Reformatted all printed messages (to make them all follow progress meter format)

- Updated region_reader to support proper bed format (off-target regions should be provided as a comma separated list of chr:start-end format in the 6'th column of the bed)
