### PR TITLE
adjust wgsim & bwa order of command-line args 

### DIFF
--- a/scripts/extract_offtarget/run.py
+++ b/scripts/extract_offtarget/run.py
@@ -37,20 +37,20 @@ indel_frac = 0.0
 indel_xtnd = 0.0
 
 
-cmd = subprocess.Popen([read_simulator, \
-                        fa_path, \
-                        fq1_path, \
-                        fq2_path, \
-                        '-e', str(base_error), \
-                        '-d', str(insert_size_mean), \
-                        '-s', str(insert_size_sdev), \
-                        '-N', str(read_count), \
-                        '-1', str(read_len), \
-                        '-2', str(read_len), \
-                        '-r', str(mutat_rate), \
-                        '-R', str(indel_frac), \
-                        '-X', str(indel_xtnd), \
-                        '-S', str(0)])
+cmd = subprocess.Popen([read_simulator,
+                        '-e', str(base_error),
+                        '-d', str(insert_size_mean),
+                        '-s', str(insert_size_sdev),
+                        '-N', str(read_count),
+                        '-1', str(read_len),
+                        '-2', str(read_len),
+                        '-r', str(mutat_rate),
+                        '-R', str(indel_frac),
+                        '-X', str(indel_xtnd),
+                        '-S', str(0),
+                        fa_path,
+                        fq1_path,
+                        fq2_path])
 cmd.wait()
 
 

--- a/scripts/extract_offtarget/run.py
+++ b/scripts/extract_offtarget/run.py
@@ -61,13 +61,13 @@ cmd.wait()
 # Align reads
 sam_path = temp_dir + exp + '.sam'
 sam_handle = open(sam_path, 'w')
-cmd = subprocess.Popen(['bwa', 'mem',\
-                        ref_genome,\
-                        fq1_path,\
-                        fq2_path,\
-                        '-M',\
-                        '-t', '4',\
-                        '-R', '@RG\tID:foo\tSM:bar'], stdout = sam_handle)
+cmd = subprocess.Popen(['bwa', 'mem',
+                        '-M',
+                        '-t', '4',
+                        '-R', '@RG\\tID:foo\\tSM:bar',
+                        ref_genome,
+                        fq1_path,
+                        fq2_path], stdout = sam_handle)
 cmd.wait()
 sam_handle.close()
 


### PR DESCRIPTION
rearranged bwa args and changed RG tabs from `\t` to `\\t`  to prevent bwa invalid args error (bwa v0.7.17-r1188 on MacOSX)