### PR TITLE
Fix read length and drop-dupes

### DIFF
--- a/src/bam_info_extract.cpp
+++ b/src/bam_info_extract.cpp
@@ -52,11 +52,12 @@ bool BamInfoExtract::GetReadLen(int32_t* read_len){
     // collecting reads mapped around locus
     bamreader->SetRegion(locus.chrom, 
 			 locus.start - flank_size > 0 ? locus.start - flank_size : 0, 
-			 locus.start + flank_size);
+			 locus.start + flank_size,
+       options->trim_to_readlen);
     num_reads = 0;
     curr_streak = 0;
     // Go through each alignment in the region until you have enough reads
-    while (bamreader->GetNextAlignment(alignment) and curr_streak < req_streak) {
+    while (bamreader->GetNextAlignment(alignment, options->trim_to_readlen) and curr_streak < req_streak) {
       has_reads = true;
       if(alignment.QueryBases().size() == curr_len){
 	curr_streak++;
@@ -107,9 +108,9 @@ bool BamInfoExtract::GetCoverageGC(std::map<std::string, SampleProfile>* profile
     // For each locus get num total bases and coverage per sample
     for (std::vector<Locus>::iterator it = gc_bin_loci.begin(); it != gc_bin_loci.end(); it++) {
       const Locus locus = *it;
-      bamreader->SetRegion(locus.chrom, locus.start, locus.end);
+      bamreader->SetRegion(locus.chrom, locus.start, locus.end, options->trim_to_readlen);
       //      std::cerr << "Locus " << locus.chrom << ":" << locus.start << " " << lb <<"-" << ub << std::endl;
-      while (bamreader->GetNextAlignment(alignment)) {
+      while (bamreader->GetNextAlignment(alignment, options->trim_to_readlen)) {
 	// Is this read worth looking at?
 	if (alignment.IsSupplementary() || alignment.IsSecondary() || 
 	    !alignment.IsProperPair()) {
@@ -179,8 +180,8 @@ bool BamInfoExtract::GetCoverage(std::map<std::string, SampleProfile>* profile,
   BamAlignment alignment;
   while ((num_regions_so_far < num_regions_to_use) &&
 	 region_reader->GetNextRegion(&locus)) {
-    bamreader->SetRegion(locus.chrom, locus.start+region_offset, locus.start+region_offset+region_length);
-    while (bamreader->GetNextAlignment(alignment)) {
+    bamreader->SetRegion(locus.chrom, locus.start+region_offset, locus.start+region_offset+region_length, options->trim_to_readlen);
+    while (bamreader->GetNextAlignment(alignment, options->trim_to_readlen)) {
       // Is this read worth looking at?
       if (alignment.IsSupplementary() || alignment.IsSecondary() || 
 	  !alignment.IsProperPair()) {
@@ -245,8 +246,8 @@ bool BamInfoExtract::GetInsertSizeDistribution(std::map<std::string, SampleProfi
   BamAlignment alignment;
   while ((num_regions_so_far < num_regions_to_use) &&
 	 region_reader->GetNextRegion(&locus)) {
-    bamreader->SetRegion(locus.chrom, locus.start+region_offset, locus.start+region_offset+region_length);
-    while (bamreader->GetNextAlignment(alignment)) {
+    bamreader->SetRegion(locus.chrom, locus.start+region_offset, locus.start+region_offset+region_length, options->trim_to_readlen);
+    while (bamreader->GetNextAlignment(alignment, options->trim_to_readlen)) {
       // Is this read worth looking at?
       if (alignment.IsSupplementary() || alignment.IsSecondary() || 
 	  !alignment.IsProperPair()) {

--- a/src/bam_info_extract.cpp
+++ b/src/bam_info_extract.cpp
@@ -43,7 +43,6 @@ bool BamInfoExtract::GetReadLen(int32_t* read_len){
   BamAlignment alignment;
   
   int32_t curr_len = 0, curr_streak = 0;
-  
   while(region_reader->GetNextRegion(&locus) and !found_read_len){
     chrom_ref_id = bam_header->ref_id(locus.chrom);
     // if (chrom_ref_id == -1){

--- a/src/bam_io.cpp
+++ b/src/bam_io.cpp
@@ -7,7 +7,7 @@
 #include "stringops.h"
 
 void BamAlignment::ExtractSequenceFields(){
-  int32_t length = b_->core.l_qseq;
+  int32_t length = 128;//b_->core.l_qseq;
   bases_         = std::string(length, ' ');
   qualities_     = std::string(length, ' '); 
   if (length == 0)

--- a/src/bam_io.h
+++ b/src/bam_io.h
@@ -320,6 +320,8 @@ class BamAlignment {
   void TrimAlignment(int32_t min_read_start, int32_t max_read_stop, char min_base_qual='~');
 
   void TrimLowQualityEnds(char min_base_qual);
+
+  void TrimEnd(int32_t trim_to);
 };
 
 
@@ -578,9 +580,9 @@ class BamCramMultiReader {
     PrintMessageDieOnError("Invalid file index provided to bam_header() function", M_ERROR, false);
   }
 
-  bool SetRegion(const std::string& chrom, int32_t start, int32_t end);
+  bool SetRegion(const std::string& chrom, int32_t start, int32_t end, int32_t trim_to);
 
-  bool GetNextAlignment(BamAlignment& aln);
+  bool GetNextAlignment(BamAlignment& aln, int32_t trim_to);
 };
 
 

--- a/src/genotyper.cpp
+++ b/src/genotyper.cpp
@@ -272,9 +272,9 @@ void Genotyper::Debug(BamCramMultiReader* bamreader) {
   refgenome->GetSequence("3", 63898261, 63898360, &seq);
   cerr << seq << endl;
   cerr << "testing bam" << endl;
-  bamreader->SetRegion("1", 0, 10000);
+  bamreader->SetRegion("1", 0, 10000, options->trim_to_readlen);
   BamAlignment aln;
-  if (bamreader->GetNextAlignment(aln)) { // Requires SetRegion was called
+  if (bamreader->GetNextAlignment(aln, options->trim_to_readlen)) { // Requires SetRegion was called
     std::string testread = aln.QueryBases();
     cerr << testread << endl;
   } else {

--- a/src/main_gangstr.cpp
+++ b/src/main_gangstr.cpp
@@ -68,7 +68,7 @@ void show_help() {
 	   << "\t" << "--nonuniform                  " << "\t" << "Indicate whether data has non-uniform coverage (i.e., exome)" << "\n"
 	   << "\t" << "--min-sample-reads <int>      " << "\t" << "Minimum number of reads per sample." << "\n"
      << "\t" << "--trim-to-readlength <int>    " << "\t" << "Trim reads longer than this length to this length." << "\n"
-     << "\t" << "--drop-dupes                  " << "\t" << "Do no process optical or PCR duplicates." << "\n"
+     << "\t" << "--drop-dupes                  " << "\t" << "Do not process optical or PCR duplicates." << "\n"
 	   << "\n Advanced paramters for likelihood model:\n"
 	   << "\t" << "--frrweight   <float>         " << "\t" << "Weight for FRR reads. Default: " << options.frr_weight << "\n"
 	   << "\t" << "--enclweight  <float>         " << "\t" << "Weight for enclosing reads. Default: " << options.enclosing_weight << "\n"

--- a/src/main_gangstr.cpp
+++ b/src/main_gangstr.cpp
@@ -67,6 +67,8 @@ void show_help() {
 	   << "\t" << "--insertsdev  <float>         " << "\t" << "Fragment length standard deviation. Comma separated list to specify for each BAM separately. " << "\n"
 	   << "\t" << "--nonuniform                  " << "\t" << "Indicate whether data has non-uniform coverage (i.e., exome)" << "\n"
 	   << "\t" << "--min-sample-reads <int>      " << "\t" << "Minimum number of reads per sample." << "\n"
+     << "\t" << "--trim-to-readlength <int>    " << "\t" << "Trim reads longer than this length to this length." << "\n"
+     << "\t" << "--drop-dupes                  " << "\t" << "Do no process optical or PCR duplicates." << "\n"
 	   << "\n Advanced paramters for likelihood model:\n"
 	   << "\t" << "--frrweight   <float>         " << "\t" << "Weight for FRR reads. Default: " << options.frr_weight << "\n"
 	   << "\t" << "--enclweight  <float>         " << "\t" << "Weight for enclosing reads. Default: " << options.enclosing_weight << "\n"
@@ -147,6 +149,8 @@ void parse_commandline_options(int argc, char* argv[], Options* options) {
     OPT_VERYVERBOSE,
     OPT_QUIET,
     OPT_VERSION,
+    OPT_TRIMTOREAD,
+    OPT_DROPDUPES
   };
   static struct option long_options[] = {
     {"max-proc-read", required_argument, NULL, OPT_MAXPROCREAD},
@@ -191,6 +195,8 @@ void parse_commandline_options(int argc, char* argv[], Options* options) {
     {"very",  no_argument, NULL, OPT_VERYVERBOSE},
     {"quiet", no_argument, NULL, OPT_QUIET},
     {"version",     no_argument,        NULL, OPT_VERSION},
+    {"trim-to-readlength",     required_argument,        NULL, OPT_TRIMTOREAD},
+    {"drop-dupes",     no_argument,        NULL, OPT_DROPDUPES},
     {NULL,          no_argument,        NULL, 0},
   };
   std::vector<std::string> dist_means_str, dist_sdev_str, coverage_str, pers;
@@ -347,6 +353,12 @@ void parse_commandline_options(int argc, char* argv[], Options* options) {
     case OPT_VERSION:
       cerr << _GIT_VERSION << endl;
       exit(0);
+    case OPT_TRIMTOREAD:
+      options->trim_to_readlen = atoi(optarg);
+      break;
+    case OPT_DROPDUPES:
+      options->drop_dupes = true;
+      break;
     case '?':
       show_help();
     default:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -90,6 +90,8 @@ Options::Options() {
   min_reads_per_sample = 500;
   max_processed_reads_per_sample = 3000;
   skip_qscore = false;
+  trim_to_readlen = -1;
+  drop_dupes = false;
 }
 
 Options::~Options() {}

--- a/src/options.h
+++ b/src/options.h
@@ -106,6 +106,9 @@ class Options {
   int32_t max_processed_reads_per_sample;
   // Skip calculation of qscore
   bool skip_qscore;
+  int32_t trim_to_readlen;
+  // Drop any reads which have 0x400 flag set to 1 in the bam file (PCR/optical duplicate)
+  bool drop_dupes;
 };
 
 #endif  // SRC_OPTIONS_H__

--- a/src/read_extractor.cpp
+++ b/src/read_extractor.cpp
@@ -730,15 +730,16 @@ bool ReadExtractor::ProcessSingleRead(BamAlignment alignment,
   if (perform_ssw) {
     bool realign_fwd = false, realign_rev = false;
     int32_t fwd_str = -1, fwd_tot = -1, rev_str = -1 ,rev_tot = -1;
+
     find_longest_stretch(seq, locus.motif, &fwd_str, &fwd_tot);
     find_longest_stretch(seq_rev, locus.motif, &rev_str, &rev_tot);
     
-    if (((locus.period == 2 and fwd_str >= 5) 
+    if (((locus.period <= 2 and fwd_str >= 5) 
 	 or (locus.period == 3 and fwd_str >= 4)
 	 or (locus.period >= 4 and fwd_str >= 3)) && fwd_str >= rev_str){
       realign_fwd = true;
     }
-    if (((locus.period == 2 and rev_str >= 5) 
+    if (((locus.period <= 2 and rev_str >= 5) 
 	 or (locus.period == 3 and rev_str >= 4)
 	 or (locus.period >= 4 and rev_str >= 3)) && rev_str >= fwd_str){
       realign_rev = true;
@@ -764,6 +765,7 @@ bool ReadExtractor::ProcessSingleRead(BamAlignment alignment,
       //cout << rev_str << " " << rev_tot << endl;
     }
     //    std::cerr << "realigning ssw: " << seq << " " << locus.motif << std::endl;
+
     if (realign_fwd){
       if (!expansion_aware_realign(seq, qual, locus.pre_flank, locus.post_flank, 
 				   locus.motif, min_match, fwd_str, fwd_tot,

--- a/src/realignment.cpp
+++ b/src/realignment.cpp
@@ -58,9 +58,9 @@ bool find_longest_stretch(const std::string& seq,
       longest_stretch = current_stretch;
     }
   }
-  if (longest_stretch >= 10){
-    cerr << longest_stretch << "\t" << seq << endl;
-  }
+  // if (longest_stretch >= 10){
+  //   cerr << longest_stretch << "\t" << seq << endl;
+  // }
   *nCopy_stretch = longest_stretch;
   *nCopy_total = total;
 }

--- a/src/realignment.cpp
+++ b/src/realignment.cpp
@@ -58,6 +58,9 @@ bool find_longest_stretch(const std::string& seq,
       longest_stretch = current_stretch;
     }
   }
+  if (longest_stretch >= 10){
+    cerr << longest_stretch << "\t" << seq << endl;
+  }
   *nCopy_stretch = longest_stretch;
   *nCopy_total = total;
 }
@@ -79,6 +82,7 @@ bool expansion_aware_realign(const std::string& seq,
 			     int32_t* score,
 			     FlankMatchState* fm_start,
 			     FlankMatchState* fm_end) {
+
   //int MIN_INTERMEDIATE_SCORE = 0.7*min_nCopy*motif.size()*SSW_MATCH_SCORE; // Give up if we don't get to this
   int MIN_INTERMEDIATE_SCORE = 0.5*seq.size()*SSW_MATCH_SCORE;
   *fm_start = FM_NOMATCH;


### PR DESCRIPTION
Version adding two new options:
1) --trim-to-readlength
2) --drop-dupes

--trim-to-readlength takes an integer value in basepairs. All reads longer than this value will be trimmed to this value from the right.
--drop-dupes is an on/off flag. If drop-drupes is set, any read with a bam flag with the 0x400 bit set to 1 will not be considered.