### PR TITLE
Fixing bugs in local realignment when flanking region matches the repeat

### DIFF
--- a/src/read_extractor.cpp
+++ b/src/read_extractor.cpp
@@ -782,8 +782,8 @@ bool ReadExtractor::ProcessSingleRead(BamAlignment alignment,
 	return false;
       }
     }
-    //  cerr << realign_fwd << "\t" << fwd_tot << " " << score << "\t" << seq << endl
-    //       << realign_rev << "\t" << rev_tot << " " << score_rev << "\t" << seq_rev << endl << endl;
+    //        cerr << realign_fwd << "\t" << fwd_tot << " " << score << "\t" << seq << "\t" << start_pos << " " << end_pos << " " << fm_start << " " << fm_end << " " << nCopy << endl
+    //      << realign_rev << "\t" << rev_tot << " " << score_rev << "\t" << seq_rev << endl << endl;
     if ((realign_fwd and score_rev > score) or (realign_rev and !realign_fwd)) {
       nCopy = nCopy_rev;
       start_pos = start_pos_rev;

--- a/src/realignment.cpp
+++ b/src/realignment.cpp
@@ -126,7 +126,7 @@ bool expansion_aware_realign(const std::string& seq,
 				&current_start_pos, &current_end_pos, &current_score, &current_num_mismatch)) {
       return false;
     }
-    
+
     // Check if this is hopeless
     //    std::cerr << seq << " " << var_realign_string << " " << motif << " " << current_nCopy << " " << current_score << std::endl;
     if (current_score < MIN_INTERMEDIATE_SCORE) {
@@ -424,9 +424,8 @@ bool classify_realigned_read(const std::string& seq,
     end_in_str = true;
   }
     
-  
   // Check if perfect flanks exist:
-  if (fm_start == FM_COMPLETE && fm_end == FM_COMPLETE){
+  if (fm_start == FM_COMPLETE && fm_end == FM_COMPLETE && !start_in_str && !end_in_str){
     *single_read_class = SR_ENCLOSING;
     return true;
   }

--- a/src/realignment.cpp
+++ b/src/realignment.cpp
@@ -174,9 +174,9 @@ bool expansion_aware_realign(const std::string& seq,
       max_end_pos = current_end_pos;
     }
   
-    if (*fm_start == FM_COMPLETE && *fm_end == FM_COMPLETE){
+    /*    if (*fm_start == FM_COMPLETE && *fm_end == FM_COMPLETE){
       break;
-    }
+      } */ // Why not continue if there is a better match?
     if (current_score == prev_score)
       current_score_run++;
     else


### PR DESCRIPTION
Based on debugging this locus in hg19: chr10:25309168-25309203, a "TATATC" repeat. This locus is problematic because the flanking region is similar to the repeat. Multiple genotypes with short repeats were called, all of which looked incorrect based on capillary electrophoresis data.

Here is the reference region:
```
TGAACTGTCATAATTTTCTTTAAAA[TATATCTATATCTATATCTATATCTATATCTATATCT]ATATATATCTACCCCAAAGTCTTG
```

Example read misclassified as "enclosing" with 4 copies. Classified as enclosing since both the start and end match the flanking sequence.
```
AAGGAACATGTTTGTGGGAAATAATATTGATACAGAATTTACAAATTGAACTGTCATAATTTTCTTTAAAATATATCTATATCTATATCTATATCTATAT
```
I added a check to make sure that reads that start or end in the repeat region cannot be classified as enclosing.

Another example:
```
GTGGGAAATAATATTGATACAGAATTTACAAATTGAACTGTCATAATTTTCTTTAAAATATATCTATATATATATCTATATCTATATCTATATCTATATC
```
classified as enclosing with 4 copies. This was because expansion aware realignment breaks if the start and ends match the flanking region. I don't think that is a good check, so commented it out.
