### PR TITLE
Fix segfault on Ubuntu 20.04

### DIFF
--- a/src/realignment.cpp
+++ b/src/realignment.cpp
@@ -60,6 +60,7 @@ bool find_longest_stretch(const std::string& seq,
   }
   *nCopy_stretch = longest_stretch;
   *nCopy_total = total;
+  return true;
 }
 
 bool expansion_aware_realign(const std::string& seq,
@@ -280,6 +281,7 @@ bool trace_back(const std::vector<std::vector<int32_t> > score_matrix,
       return false;
     }
   }
+  return true;
 }
 
 bool next_move(std::vector<std::vector<int32_t> > score_matrix, 


### PR DESCRIPTION
With optimisation on, this Ubuntu version's compiler was miscompiling `find_longest_stretch()` such that it would always crash. Adding the missing `return` makes it optimise the function correctly. Fixes #92.

Similarly update `trace_back()` even though it appears to be currently unused.

You may want to consider investigating any other warnings produced while compiling GangSTR :smile: